### PR TITLE
fix(sandbox): landlock 0.4.5 API compatibility

### DIFF
--- a/crates/sandbox/src/backend/landlock.rs
+++ b/crates/sandbox/src/backend/landlock.rs
@@ -10,7 +10,7 @@
 //! Landlock and are silently ignored.
 
 use landlock::{
-    ABI, Access, AccessFs, Ruleset, RulesetAttr, RulesetCreated, RulesetHandle, RulesetStatus,
+    ABI, Access, AccessFs, BitFlags, Ruleset, RulesetAttr, RulesetCreatedAttr, RulesetStatus,
     path_beneath_rules,
 };
 
@@ -134,7 +134,7 @@ fn parse_kernel_version(version: &str) -> Option<(u32, u32)> {
 }
 
 /// Convert our `PathAccess` to Landlock `AccessFs` flags.
-fn path_access_to_landlock(access: PathAccess, abi: ABI) -> AccessFs {
+fn path_access_to_landlock(access: PathAccess, abi: ABI) -> BitFlags<AccessFs> {
     match access {
         PathAccess::ReadOnly => AccessFs::from_read(abi),
         PathAccess::ReadWrite => AccessFs::from_read(abi) | AccessFs::from_write(abi),


### PR DESCRIPTION
## Problem

`crab-sandbox` fails to compile with `landlock = "0.4"` (resolves to 0.4.5). The landlock crate made a breaking change within the 0.4.x semver range.

Closes #96

## Changes

All changes in `crates/sandbox/src/backend/landlock.rs`:

1. **Imports**: Added `Access`, `BitFlags`, `RulesetCreatedAttr`; removed unused `RulesetHandle`
2. **Return type**: `path_access_to_landlock` now returns `BitFlags<AccessFs>` instead of `AccessFs`
3. **Removed `.into()` calls**: `from_read`/`from_write`/`from_all` already return `BitFlags<AccessFs>`

## Verification

```bash
cargo build --release -p crab-cli
# Compiles successfully, produces 34M binary
```

## Error messages before fix

```
error[E0432]: unresolved import `landlock::RulesetHandle`
error[E0599]: no method named `add_rules` found (needs RulesetCreatedAttr trait)
error[E0308]: expected `AccessFs`, found `BitFlags<AccessFs, u64>`
error[E0599]: no associated function `from_all` (needs Access trait)
```